### PR TITLE
Game logic: Execute movement last

### DIFF
--- a/src/core/game.cpp
+++ b/src/core/game.cpp
@@ -70,7 +70,6 @@ bool Game::logic() {
   }
   ++ticks;
 
-  movement(reg);
   wallCollide(reg, maze);
   dots += eatDots(reg, maze);
   if (eatEnergizer(reg, maze)) {
@@ -97,6 +96,9 @@ bool Game::logic() {
   } else if (dots == dotsInMaze) {
     state = State::won;
   }
+
+  movement(reg);
+
   return true;
 }
 

--- a/src/sys/render.cpp
+++ b/src/sys/render.cpp
@@ -19,10 +19,12 @@
 void playerRender(entt::registry &reg, SDL::QuadWriter &writer, const int frame) {
   const auto view = reg.view<Position, ActualDir, DesiredDir, PlayerSprite>();
   for (const entt::entity e : view) {
-    const Pos pos = view.get<Position>(e).p * tileSize;
+    const Pos currentPos = view.get<Position>(e).p * tileSize;
     const Dir actualDir = view.get<ActualDir>(e).d;
     const double angle = static_cast<double>(view.get<DesiredDir>(e).d) * 90.0;
-    writer.tilePos(pos + toPos(actualDir, frame), Pos{tileSize, tileSize}, angle);
+    const Pos deltaPos = toPos(actualDir, tileSize);
+    const Pos lastPos = currentPos - deltaPos;
+    writer.tilePos(lastPos + toPos(actualDir, frame), Pos{tileSize, tileSize}, angle);
     writer.tileTex(view.get<PlayerSprite>(e).id + frame);
     writer.render();
   }
@@ -31,9 +33,11 @@ void playerRender(entt::registry &reg, SDL::QuadWriter &writer, const int frame)
 void ghostRender(entt::registry &reg, SDL::QuadWriter &writer, const int frame) {
   const auto view = reg.view<Position, ActualDir, GhostSprite>();
   for (const entt::entity e : view) {
-    const Pos pos = view.get<Position>(e).p * tileSize;
+    const Pos currentPos = view.get<Position>(e).p * tileSize;
     const Dir actualDir = view.get<ActualDir>(e).d;
-    writer.tilePos(pos + toPos(actualDir, frame), Pos{tileSize, tileSize});
+    const Pos deltaPos = toPos(actualDir, tileSize);
+    const Pos lastPos = currentPos - deltaPos;
+    writer.tilePos(lastPos + toPos(actualDir, frame), Pos{tileSize, tileSize});
     const int dirOffset = (
       actualDir == Dir::none ? 0 : static_cast<int>(actualDir)
     );


### PR DESCRIPTION
Closes https://github.com/KIT-MRT/arbitration_graphs/issues/12, checkout that issue for a full description of the problem.

The issue is solved by executing the movement as the very last step of the `Game::logic()` function. The side effect of glitchy renderings is solved by "undoing" the movement again in the rendering.
So previously the entities where rendered from their current position to the next position after which the movement would be executed. Now, the movement is executed first and the entities are rendered from their last position to their current position.

There is probably a nicer way to fix this but my solution is "minimally invasive" and solves the timing issue in the arbitrator demo without side effects to this repo (on the contrary - playing manually should feel slightly smoother as well).